### PR TITLE
handle expired RRSIGs

### DIFF
--- a/dnssec-tools/tools/scripts/check-zone-expiration
+++ b/dnssec-tools/tools/scripts/check-zone-expiration
@@ -34,7 +34,10 @@ foreach my $zone (@ARGV) {
 	if (!defined($opts{'m'}) || $delta <= $opts{'m'}) {
 	    $count++;
 	    # 22 characters for zone should almost always print < 80 total
-	    printf("%-22.22s will expire in %s\n", $zone, timetrans($delta));
+	    printf("%-22.22s %s %s\n", 
+		$zone,
+		$delta < 0 ? 'is expired since' : 'will expire in',
+		timetrans(abs($delta)));
 	}
     } else {
 	print "Failed to query for RRSIGs for '$zone'\n";


### PR DESCRIPTION
`check-zone-expiration` prints a confusing `example.com will expire in ` (i.e., no time range) if the signature is already expired. 